### PR TITLE
set the charset with the content type

### DIFF
--- a/lib/podlet-plugin.js
+++ b/lib/podlet-plugin.js
@@ -29,7 +29,7 @@ const podiumPodletFastifyPlugin = (fastify, podlet, done) => {
 
     // Decorate response with .podiumSend() method
     fastify.decorateReply('podiumSend', function podiumSend(payload) {
-        this.type('text/html'); // "this" here is the fastify 'Reply' object
+        this.type('text/html; charset=utf-8'); // "this" here is the fastify 'Reply' object
         this.send(podlet.render(this.app.podium, payload));
     });
 


### PR DESCRIPTION
Noticed this while trying to deploy a Fastify version of the footer. Resulted in incorrectly encoded Norwegian characters.