### PR TITLE
fix: Move Podium processing to a preHandler hook

### DIFF
--- a/lib/podlet-plugin.js
+++ b/lib/podlet-plugin.js
@@ -8,12 +8,15 @@ const fp = require('fastify-plugin');
 
 const podiumPodletFastifyPlugin = (fastify, podlet, done) => {
     // Decorate reply with .app.podium we can write to throught the request
-    fastify.decorateReply('app', {
-        podium: {},
+    fastify.decorateReply('app', null);
+    fastify.addHook('onRequest', async (request, reply) => {
+        reply.app = {
+            podium: {},
+        };
     });
 
-    // Run parsers on request and store state object on reply.app.podium
-    fastify.addHook('onRequest', async (request, reply) => {
+    // Run parsers on pre handler and store state object on reply.app.podium
+    fastify.addHook('preHandler', async (request, reply) => {
         const incoming = new utils.HttpIncoming(
             request.raw,
             reply.raw,


### PR DESCRIPTION
This moves the Podium processing, which includes processing the context, to a pre handler hook instead of running it on the on request hook.

The reason for this move is that if one extend the context with additional which rely on other hooks, running the context parsers on the on request hook is too early. In other words, the podium processing of the context parsers is run before the custom parsers is done.

This replicates the behaviour in the layout: https://github.com/podium-lib/fastify-layout/pull/101