### PR TITLE
fix: removing invalid badge with fix to trigger new release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Fastify plugin for @podium/podlet.
 
-[![Dependencies](https://img.shields.io/david/podium-lib/fastify-podlet.svg)](https://david-dm.org/podium-lib/fastify-podlet)
 [![GitHub Actions status](https://github.com/podium-lib/fastify-podlet/workflows/Run%20Lint%20and%20Tests/badge.svg)](https://github.com/podium-lib/fastify-podlet/actions?query=workflow%3A%22Run+Lint+and+Tests%22)
 [![Known Vulnerabilities](https://snyk.io/test/github/podium-lib/fastify-podlet/badge.svg)](https://snyk.io/test/github/podium-lib/fastify-podlet)
 


### PR DESCRIPTION
Commit [f3dc6ff](https://github.com/podium-lib/fastify-podlet/commit/f3dc6ffc096f2fce7c1afc043de1e46d94800d6a) had an invalid commit message which did not trigger a release. 
This PR corrects that and also remove the badge for dependencies which does not respond anymore.
