### PR TITLE
chore: clearer naming of the plugin in docs / examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module require Fastify v2.0.0 or newer.
 Build a simple podlet server:
 
 ```js
-const fastifyPodlet = require('@podium/fastify-podlet');
+const fastifyPodletPlugin = require('@podium/fastify-podlet');
 const fastify = require('fastify');
 const Podlet = require('@podium/podlet');
 
@@ -36,7 +36,8 @@ const podlet = new Podlet({
     name: 'podletContent',
 });
 
-app.register(fastifyPodlet, podlet);
+// Register the plugin, with the podlet as the option
+app.register(fastifyPodletPlugin, podlet);
 
 app.get(podlet.content(), async (request, reply) => {
     if (reply.app.podium.context.locale === 'nb-NO') {
@@ -69,7 +70,7 @@ server `.register()` method together with an instance of the [@podium/podlet]
 class.
 
 ```js
-app.register(FastifyPodlet, podlet);
+app.register(fastifyPodletPlugin, podlet);
 ```
 
 ## Request params

--- a/example/server.js
+++ b/example/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const FastifyPodlet = require('../');
+const fastifyPodletPlugin = require('../');
 const fastify = require('fastify');
 const Podlet = require('@podium/podlet');
 
@@ -19,7 +19,7 @@ podlet.defaults({
     locale: 'nb-NO',
 });
 
-app.register(FastifyPodlet, podlet);
+app.register(fastifyPodletPlugin, podlet);
 
 app.get(podlet.content(), async (request, reply) => {
     if (reply.app.podium.context.locale === 'nb-NO') {

--- a/test/podlet-plugin.js
+++ b/test/podlet-plugin.js
@@ -7,7 +7,7 @@ const { request } = require('@podium/test-utils');
 const fastify = require('fastify');
 const Podlet = require('@podium/podlet');
 const tap = require('tap');
-const FastifyPodlet = require('..');
+const fastifyPodletPlugin = require('..');
 
 class Server {
     constructor(options = {}) {
@@ -27,7 +27,7 @@ class Server {
             locale: 'nb-NO',
         });
 
-        this.app.register(FastifyPodlet, podlet);
+        this.app.register(fastifyPodletPlugin, podlet);
         this.app.register(fastifyForm); // Needed to handle non GET requests
 
         this.app.get(podlet.content(), async (req, reply) => {


### PR DESCRIPTION
Making the docs and examples clearer by naming what _is_ a Fastify plugin exactly that.