### PR TITLE
fix: return fastifyreply so async/await works as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ please see the [Podium documentation].
 ## Installation
 
 ```bash
-$ npm install @podium/fastify-podlet
+npm install @podium/fastify-podlet
 ```
 
 ## Requirements
@@ -40,16 +40,13 @@ app.register(fastifyPodletPlugin, podlet);
 
 app.get(podlet.content(), async (request, reply) => {
     if (reply.app.podium.context.locale === 'nb-NO') {
-        reply.podiumSend('<h2>Hei verden</h2>');
-        return;
+        return reply.podiumSend('<h2>Hei verden</h2>');
     }
-    reply.podiumSend('<h2>Hello world</h2>');
-    await reply;
+    return reply.podiumSend('<h2>Hello world</h2>');
 });
 
 app.get(podlet.manifest(), async (request, reply) => {
-    reply.send(podlet);
-    await reply;
+    return reply.send(podlet);
 });
 
 const start = async () => {
@@ -85,11 +82,9 @@ accessible inside a request handelers.
 ```js
 app.get(podlet.content(), async (request, reply) => {
     if (reply.app.podium.context.locale === 'nb-NO') {
-        reply.podiumSend('<h2>Hei verden</h2>');
-        return;
+        return reply.podiumSend('<h2>Hei verden</h2>');
     }
-    reply.podiumSend('<h2>Hello world</h2>');
-    await reply;
+    return reply.podiumSend('<h2>Hello world</h2>');
 });
 ```
 

--- a/lib/podlet-plugin.js
+++ b/lib/podlet-plugin.js
@@ -35,7 +35,7 @@ export default fp(
         // Decorate response with .podiumSend() method
         fastify.decorateReply('podiumSend', function podiumSend(payload) {
             this.type('text/html; charset=utf-8'); // "this" here is the fastify 'Reply' object
-            this.send(
+            return this.send(
                 podlet.render(
                     // @ts-ignore We decorate this above
                     this.app.podium,

--- a/test/podlet-plugin.js
+++ b/test/podlet-plugin.js
@@ -28,35 +28,33 @@ class Server {
 
         this.app.get(podlet.content(), async (req, reply) => {
             if (reply.app.podium.context.locale === 'nb-NO') {
-                reply.podiumSend('nb-NO');
-                return;
+                return reply.podiumSend('nb-NO');
             }
             if (reply.app.podium.context.locale === 'en-NZ') {
-                reply.podiumSend('en-NZ');
-                return;
+                return reply.podiumSend('en-NZ');
             }
-            reply.podiumSend('en-US');
+            return reply.podiumSend('en-US');
         });
 
         this.app.get(podlet.fallback(), async (req, reply) => {
-            reply.podiumSend('fallback');
+            return reply.podiumSend('fallback');
         });
 
         this.app.get(podlet.manifest(), async (req, reply) => {
-            reply.send(podlet);
+            return reply.send(podlet);
         });
 
         // Dummy endpoints for proxying
         this.app.get('/public', async (req, reply) => {
-            reply.send('GET proxy target');
+            return reply.send('GET proxy target');
         });
 
         this.app.post('/public', async (req, reply) => {
-            reply.send('POST proxy target');
+            return reply.send('POST proxy target');
         });
 
         this.app.put('/public', async (req, reply) => {
-            reply.send('PUT proxy target');
+            return reply.send('PUT proxy target');
         });
 
         // Proxy to the dummy endpoints

--- a/types/podium.d.ts
+++ b/types/podium.d.ts
@@ -1,9 +1,7 @@
 import { HttpIncoming } from '@podium/utils';
 
 declare module 'fastify' {
-    
-
-    interface PodiumHttpIncomingParameters { 
+    interface PodiumHttpIncomingParameters {
         [key: string]: unknown;
     }
 
@@ -13,30 +11,31 @@ declare module 'fastify' {
         [key: string]: unknown;
     }
 
-    interface PodiumHttpIncomingViewParameters { 
+    interface PodiumHttpIncomingViewParameters {
         [key: string]: unknown;
     }
 
     interface PodiumLocals {
-        podium: HttpIncoming<PodiumHttpIncomingParameters, PodiumHttpIncomingContext, PodiumHttpIncomingViewParameters>;
+        podium: HttpIncoming<
+            PodiumHttpIncomingParameters,
+            PodiumHttpIncomingContext,
+            PodiumHttpIncomingViewParameters
+        >;
     }
 
     interface FastifyReply {
         app: PodiumLocals;
 
         /**
-         * Calls the send / write method on the `http.ServerResponse` object.
-         *
          * When in development mode this method will wrap the provided fragment in a
          * default HTML document before dispatching. When not in development mode, this
          * method will just dispatch the fragment.
          *
          * @example
          * app.get(podlet.content(), async (req, reply) => {
-         *   reply.podiumSend('<h1>Hello World</h1>');
-         *   await reply;
+         *   return reply.podiumSend('<h1>Hello World</h1>');
          * });
          */
-        podiumSend(fragment: string, ...args: unknown[]): Response;
+        podiumSend(fragment: string, ...args: unknown[]): FastifyReply;
     }
 }


### PR DESCRIPTION
Fit the `return reply.send` pattern of async/await in Fastify

https://fastify.dev/docs/latest/Reference/Routes/#async-await